### PR TITLE
Fixed dangling kotlin-dotenv link at the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ for (DotenvEntry e : dotenv.entries()) {
 
 ## Powered by dotenv-java
 - [spring-dotenv](https://github.com/paulschwarz/spring-dotenv) - dotenv-java as a Spring PropertySource
-- [dotenv-kotlin](https://github.com/cdimascio/kotlin-dotenv) - a Kotlin DSL for dotenv-java
+- [dotenv-kotlin](https://github.com/cdimascio/dotenv-kotlin) - a Kotlin DSL for dotenv-java
 
 ## [Javadoc](https://cdimascio.github.io/dotenv-java/docs/javadoc/)
 


### PR DESCRIPTION
The `kotlin-dotenv` repository doesn't exists, it's `dotenv-kotlin`.