### PR TITLE
Offer a `recurseParent()` config option

### DIFF
--- a/src/main/java/io/github/cdimascio/dotenv/DotenvBuilder.java
+++ b/src/main/java/io/github/cdimascio/dotenv/DotenvBuilder.java
@@ -17,6 +17,7 @@ public class DotenvBuilder {
     private boolean systemProperties = false;
     private boolean throwIfMissing = true;
     private boolean throwIfMalformed = true;
+    private boolean recurse = false;
 
     /**
      * Sets the directory containing the .env file.
@@ -55,6 +56,16 @@ public class DotenvBuilder {
         return this;
     }
 
+
+    /**
+     * Recursively search parent directories for a .env file
+     * @return this {@link DotenvBuilder}
+     */
+    public DotenvBuilder recurseParents() {
+        recurse = true;
+        return this;
+    }
+
     /**
      * Sets each environment variable as system properties.
      * @return this {@link DotenvBuilder}
@@ -71,7 +82,7 @@ public class DotenvBuilder {
      */
     public Dotenv load() throws DotenvException {
         DotenvParser reader = new DotenvParser(
-            new DotenvReader(directoryPath, filename),
+            new DotenvReader(directoryPath, filename, recurse),
             throwIfMissing,
             throwIfMalformed);
         List<DotenvEntry> env = reader.parse();

--- a/src/main/java/io/github/cdimascio/dotenv/internal/DotenvReader.java
+++ b/src/main/java/io/github/cdimascio/dotenv/internal/DotenvReader.java
@@ -17,15 +17,18 @@ import java.util.stream.Collectors;
 public class DotenvReader {
     private final String directory;
     private final String filename;
+    private final boolean recurse;
 
     /**
      * Creates a dotenv reader
      * @param directory the directory containing the .env file
      * @param filename the file name of the .env file e.g. .env
+     * @param recurse
      */
-    public DotenvReader(String directory, String filename) {
+    public DotenvReader(String directory, String filename, boolean recurse) {
         this.directory = directory;
         this.filename = filename;
+        this.recurse = recurse;
     }
 
     /**
@@ -50,6 +53,18 @@ public class DotenvReader {
             return Files
                 .lines(path)
                 .collect(Collectors.toList());
+        } else if (recurse) {
+            Path parent = path.getParent().getParent(); // get the parent of the parent of the current .env file
+            while (parent != null) {
+                Path fileInParent = parent.resolve(filename);  // resolve a .env file in it
+                if (Files.exists(fileInParent)) {
+                    return Files
+                        .lines(fileInParent)
+                        .collect(Collectors.toList());
+                } else {
+                    parent = parent.getParent();
+                }
+            }
         }
 
         try {

--- a/src/test/java/tests/BasicTests.java
+++ b/src/test/java/tests/BasicTests.java
@@ -141,4 +141,16 @@ public class BasicTests {
             assertEquals(expectedHome, actualHome);
         }
     }
+
+    @Test
+    public void parentDirectory() {
+        var dotenv = Dotenv.configure()
+            .directory("./src/test/resources/parent_demo")
+            .recurseParents()
+            .ignoreIfMalformed()
+            .load();
+        assertEquals("my test ev 1", dotenv.get("MY_TEST_EV1"));
+
+        assertHostEnvVar(dotenv);
+    }
 }


### PR DESCRIPTION
This change allows you to configure a recursive search through parent directories for a .env file.  This is useful in a multi-module project when you want to share a common .env file across multiple modules.

No worries if this isn't a feature you want, but I needed it for my own project.