### PR TITLE
Fix classpath relative-to-absolute conversion in DotenvReader

### DIFF
--- a/src/main/java/io/github/cdimascio/dotenv/internal/DotenvReader.java
+++ b/src/main/java/io/github/cdimascio/dotenv/internal/DotenvReader.java
@@ -54,7 +54,7 @@ public class DotenvReader {
 
         try {
             return ClasspathHelper
-                .loadFileFromClasspath(location.replaceFirst("./", "/"))
+                .loadFileFromClasspath(location.replaceFirst("^\\./", "/"))
                 .collect(Collectors.toList());
         } catch (DotenvException e) {
             Path cwd = FileSystems.getDefault().getPath(".").toAbsolutePath().normalize();

--- a/src/test/java/tests/BasicTests.java
+++ b/src/test/java/tests/BasicTests.java
@@ -67,6 +67,36 @@ public class BasicTests {
     }
 
     @Test
+    public void resourceAbsoluteDir() {
+        dirTest("/envdir","Simple Subdirectory");
+    }
+
+    @Test
+    public void resourceRelativeDir() {
+        dirTest("./envdir", "Simple Subdirectory");
+    }
+
+    @Test
+    public void resourceUnanchoredDir() {
+        dirTest("envdir", "Simple Subdirectory");
+    }
+
+    @Test
+    public void resourceAbsoluteTrailingDotDir() {
+        dirTest("/trailingdot./envdir", "Trailing Dot Directory With Subdirectory");
+    }
+
+    @Test
+    public void resourceRelativeTrailingDotDir() {
+        dirTest("./trailingdot./envdir", "Trailing Dot Directory With Subdirectory");
+    }
+
+    @Test
+    public void resourceUnanchoredTrailingDotDir() {
+        dirTest("trailingdot./envdir", "Trailing Dot Directory With Subdirectory");
+    }
+
+    @Test
     public void resourceCurrent() {
         var dotenv = Dotenv.configure()
             .ignoreIfMalformed()
@@ -128,6 +158,13 @@ public class BasicTests {
         assertHostEnvVar(dotenv);
 
         assertNull(dotenv.get("MY_TEST_EV1"));
+    }
+
+    private void dirTest(String path, String expected) {
+        var dotenv = Dotenv.configure()
+            .directory(path)
+            .load();
+        assertEquals(expected, dotenv.get("MY_TEST_EV1"));
     }
 
     private void assertHostEnvVar(Dotenv env) {

--- a/src/test/java/tests/BasicTests.java
+++ b/src/test/java/tests/BasicTests.java
@@ -68,32 +68,32 @@ public class BasicTests {
 
     @Test
     public void resourceAbsoluteDir() {
-        dirTest("/envdir","Simple Subdirectory");
+        assertDirectory("/envdir","Simple Subdirectory");
     }
 
     @Test
     public void resourceRelativeDir() {
-        dirTest("./envdir", "Simple Subdirectory");
+        assertDirectory("./envdir", "Simple Subdirectory");
     }
 
     @Test
     public void resourceUnanchoredDir() {
-        dirTest("envdir", "Simple Subdirectory");
+        assertDirectory("envdir", "Simple Subdirectory");
     }
 
     @Test
     public void resourceAbsoluteTrailingDotDir() {
-        dirTest("/trailingdot./envdir", "Trailing Dot Directory With Subdirectory");
+        assertDirectory("/trailingdot./envdir", "Trailing Dot Directory With Subdirectory");
     }
 
     @Test
     public void resourceRelativeTrailingDotDir() {
-        dirTest("./trailingdot./envdir", "Trailing Dot Directory With Subdirectory");
+        assertDirectory("./trailingdot./envdir", "Trailing Dot Directory With Subdirectory");
     }
 
     @Test
     public void resourceUnanchoredTrailingDotDir() {
-        dirTest("trailingdot./envdir", "Trailing Dot Directory With Subdirectory");
+        assertDirectory("trailingdot./envdir", "Trailing Dot Directory With Subdirectory");
     }
 
     @Test
@@ -160,9 +160,9 @@ public class BasicTests {
         assertNull(dotenv.get("MY_TEST_EV1"));
     }
 
-    private void dirTest(String path, String expected) {
+    private void assertDirectory(String directory, String expected) {
         var dotenv = Dotenv.configure()
-            .directory(path)
+            .directory(directory)
             .load();
         assertEquals(expected, dotenv.get("MY_TEST_EV1"));
     }

--- a/src/test/resources/envdir/.env
+++ b/src/test/resources/envdir/.env
@@ -1,0 +1,2 @@
+## Good test EV
+MY_TEST_EV1=Simple Subdirectory

--- a/src/test/resources/trailingdot./envdir/.env
+++ b/src/test/resources/trailingdot./envdir/.env
@@ -1,0 +1,2 @@
+## Good test EV
+MY_TEST_EV1=Trailing Dot Directory With Subdirectory


### PR DESCRIPTION
Escape `.` to prevent removing the trailing character from a simple directory name with no leading `/` or `./`

Anchor the regex to prevent stripping a trailing literal `.` from a directory name, which is unlikely but possible

Add tests for simple resource directory and resource directory with trailing `.`

Examples of bug:
`.directory("envdir")` would try to load `resources/envdi/.env` and fail
`.directory("/trailingdot./envdir")` would try to load `resources/trailingdot/envdir/.env` and fail

Workaround: Always prefix classpath-relative directories with `./`