### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,16 @@ _Requires Java 8 or greater._
 </dependency>
 ```
 
-### Gradle
+### Gradle <4.10
 
 ```groovy
 compile 'io.github.cdimascio:dotenv-java:2.2.4'
+```
+
+### Gradle >=4.10
+
+```groovy
+implementation 'io.github.cdimascio:dotenv-java:2.2.4'
 ```
 
 Looking for the Kotlin variant? **get [dotenv-kotlin](https://github.com/cdimascio/dotenv-kotlin)**.


### PR DESCRIPTION
The `compile` configuration has been deprecated since Gradle 4.10 and it was finally removed in Gradle 7.0, being replaced by `implementation`, as can be seen [here](https://docs.gradle.org/4.10/userguide/java_plugin.html#sec:java_plugin_and_dependency_management) and [here](https://docs.gradle.org/7.0/userguide/java_library_plugin.html#sec:java_library_configurations_graph), respectively.