### PR TITLE
docs: fix android code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ dotenv.get("MY_ENV_VAR1")
 	```java
     Dotenv dotenv = Dotenv.configure()
        .directory("/assets")
-       .filename("env"); // instead of '.env', use 'env'
+       .filename("env") // instead of '.env', use 'env'
+       .load();
 
 	dotenv.get("MY_ENV_VAR1");
 	```


### PR DESCRIPTION
Update the android code example in the README.md to call the load method after configuring the builder.

Fixes https://github.com/cdimascio/dotenv-java/issues/32.