### PR TITLE
Support trailing comments

### DIFF
--- a/src/main/java/io/github/cdimascio/dotenv/internal/DotenvParser.java
+++ b/src/main/java/io/github/cdimascio/dotenv/internal/DotenvParser.java
@@ -23,7 +23,8 @@ public class DotenvParser {
     private final Function<String, Boolean> isWhiteSpace = s -> matches("^\\s*$", s); // ^\s*${'$'}
     private final Function<String, Boolean> isComment = s -> s.startsWith("#") || s.startsWith("////");
     private final Function<String, Boolean> isQuoted = s -> s.startsWith("\"") && s.endsWith("\"");
-    private final Function<String, DotenvEntry> parseLine = s -> matchEntry("^\\s*([\\w.\\-]+)\\s*(=)\\s*(.*)?\\s*$", s); // ^\s*([\w.\-]+)\s*(=)\s*(.*)?\s*$
+    private final Function<String, DotenvEntry> parseLine =
+        s -> matchEntry("^\\s*([\\w.\\-]+)\\s*(=)\\s*([^#]*)?\\s*(#.*)?$", s);
 
     /**
      * Creates a dotenv parser

--- a/src/test/java/tests/BasicTests.java
+++ b/src/test/java/tests/BasicTests.java
@@ -15,6 +15,7 @@ public class BasicTests {
         put("MY_TEST_EV2", "my test ev 2");
         put("WITHOUT_VALUE", "");
         put("MULTI_LINE", "hello\\nworld");
+        put("TRAILING_COMMENT", "value");
     }};
 
     @Test(expected = DotenvException.class)

--- a/src/test/resources/.env
+++ b/src/test/resources/.env
@@ -3,6 +3,7 @@ MY_TEST_EV1=my test ev 1
 MY_TEST_EV2=my test ev 2
 WITHOUT_VALUE=
 MULTI_LINE=hello\nworld
+TRAILING_COMMENT=value # comment
 
 ## Malformed EV!
 MY_TEST_EV3

--- a/src/test/resources/env
+++ b/src/test/resources/env
@@ -3,6 +3,7 @@ MY_TEST_EV1=my test ev 1
 MY_TEST_EV2=my test ev 2
 WITHOUT_VALUE=
 MULTI_LINE=hello\nworld
+TRAILING_COMMENT=value # comment
 
 ## Malformed EV!
 MY_TEST_EV3


### PR DESCRIPTION
The original Ruby dotenv supports trailing comments as it is valid shell syntax. In general it would be good to conform to the regular expression as defined here:
https://github.com/bkeepers/dotenv/blob/master/lib/dotenv/parser.rb#L14-L30