### PR TITLE
Update build workflow to upload JaCoCo code coverage report to codacy.com

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,3 +27,8 @@ jobs:
           cache: maven
       - name: Build with Maven
         run: mvn clean package jacoco:report
+      - name: Codacy coverage report upload
+        env:
+          CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
+        run: |
+          test -z $CODACY_PROJECT_TOKEN || bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r target/site/jacoco/jacoco.xml


### PR DESCRIPTION
In order to make the upload work you need to get a codacy project token. 

## Getting the coverage badge and codacy project token

- access your project at https://codacy.com, go to "Settings" at the left sidebar
- go to the "General" tab at the top and copy the coverage badge, adding to your README.md.
- go to the "Integrations" tab, open the "Project API" and copy the "Project API Token"

## Access your GitHub repository settings tab at the top

- click the "Secrets and variables" at the left side bar, then "actions"
- click the "New repository secret" button and create a variable named `CODACY_PROJECT_TOKEN`. Its value must the the one copied from the Codacy's "Project API Token" field.