### PR TITLE
Crashes_on_Android_version_7_and_older

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
     <javadoc.dir>docs/javadoc</javadoc.dir>
 
     <junit.version>5.9.2</junit.version>
+    <mockito.version>5.3.1</mockito.version>
 
     <maven.enforcer.plugin>3.3.0</maven.enforcer.plugin>
     <maven.compiler.plugin>3.11.0</maven.compiler.plugin>
@@ -94,6 +95,12 @@
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
       <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/io/github/cdimascio/dotenv/DotenvBuilder.java
+++ b/src/main/java/io/github/cdimascio/dotenv/DotenvBuilder.java
@@ -64,7 +64,7 @@ public class DotenvBuilder {
         return this;
     }
 
-    private boolean pathsApiAvailable() {
+    protected boolean pathsApiAvailable() {
         try {
             final String packageName = "java.nio.file";
             final Class<?> clazz = Class.forName(packageName + "." + "Paths");

--- a/src/main/java/io/github/cdimascio/dotenv/DotenvBuilder.java
+++ b/src/main/java/io/github/cdimascio/dotenv/DotenvBuilder.java
@@ -2,6 +2,7 @@ package io.github.cdimascio.dotenv;
 
 import io.github.cdimascio.dotenv.internal.DotenvFileReader;
 import io.github.cdimascio.dotenv.internal.DotenvParser;
+import io.github.cdimascio.dotenv.internal.DotenvPathReader;
 
 import java.util.*;
 
@@ -81,7 +82,7 @@ public class DotenvBuilder {
      */
     public Dotenv load() throws DotenvException {
         final var fileReader = pathsApiAvailable() ?
-            new DotenvFileReader(directoryPath, filename) : new DotenvFileReader(directoryPath, filename);
+            new DotenvPathReader(directoryPath, filename) : new DotenvFileReader(directoryPath, filename);
         final var reader = new DotenvParser(
             fileReader,
             throwIfMissing, throwIfMalformed);

--- a/src/main/java/io/github/cdimascio/dotenv/DotenvBuilder.java
+++ b/src/main/java/io/github/cdimascio/dotenv/DotenvBuilder.java
@@ -67,7 +67,7 @@ public class DotenvBuilder {
     protected boolean pathsApiAvailable() {
         try {
             final String packageName = "java.nio.file";
-            final Class<?> clazz = Class.forName(packageName + "." + "Paths");
+            Class.forName(packageName + "." + "Paths");
             return true;
         } catch (Exception e) {
         }

--- a/src/main/java/io/github/cdimascio/dotenv/DotenvBuilder.java
+++ b/src/main/java/io/github/cdimascio/dotenv/DotenvBuilder.java
@@ -1,7 +1,7 @@
 package io.github.cdimascio.dotenv;
 
+import io.github.cdimascio.dotenv.internal.DotenvPathReader;
 import io.github.cdimascio.dotenv.internal.DotenvParser;
-import io.github.cdimascio.dotenv.internal.DotenvReader;
 
 import java.util.*;
 
@@ -71,7 +71,7 @@ public class DotenvBuilder {
      */
     public Dotenv load() throws DotenvException {
         final var reader = new DotenvParser(
-                                new DotenvReader(directoryPath, filename),
+                                new DotenvPathReader(directoryPath, filename),
                                 throwIfMissing, throwIfMalformed);
         final List<DotenvEntry> env = reader.parse();
         if (systemProperties) {

--- a/src/main/java/io/github/cdimascio/dotenv/internal/BaseDotenvReader.java
+++ b/src/main/java/io/github/cdimascio/dotenv/internal/BaseDotenvReader.java
@@ -1,0 +1,34 @@
+package io.github.cdimascio.dotenv.internal;
+
+import io.github.cdimascio.dotenv.DotenvException;
+
+import java.io.IOException;
+import java.util.List;
+
+public abstract class BaseDotenvReader implements DotenvReader {
+    protected final String directory;
+    protected final String filename;
+
+    /**
+     * Creates a dotenv reader
+     * @param directory the directory containing the .env file
+     * @param filename the file name of the .env file e.g. .env
+     */
+    public BaseDotenvReader(String directory, String filename) {
+        this.directory = directory;
+        this.filename = filename;
+    }
+
+    public abstract List<String> read() throws DotenvException, IOException;
+
+
+
+    protected String sanitizeDirectory() {
+        String dir = directory
+            .replaceAll("\\\\", "/")
+            .replaceFirst("\\.env$", "")
+            .replaceFirst("/$", "");
+        return dir;
+    }
+
+}

--- a/src/main/java/io/github/cdimascio/dotenv/internal/ClasspathHelper.java
+++ b/src/main/java/io/github/cdimascio/dotenv/internal/ClasspathHelper.java
@@ -2,6 +2,7 @@ package io.github.cdimascio.dotenv.internal;
 
 import io.github.cdimascio.dotenv.DotenvException;
 
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Scanner;
@@ -12,6 +13,18 @@ import java.util.stream.Stream;
  */
 public class ClasspathHelper {
     static Stream<String> loadFileFromClasspath(String location) {
+        InputStream inputStream = getInputStream(location);
+
+        final var scanner = new Scanner(inputStream, StandardCharsets.UTF_8);
+        final var lines = new ArrayList<String>();
+        while (scanner.hasNext()) {
+            lines.add(scanner.nextLine());
+        }
+
+        return lines.stream();
+    }
+
+    static InputStream getInputStream(String location) {
         final var loader = ClasspathHelper.class;
         var inputStream = loader.getResourceAsStream(location);
         if (inputStream == null) {
@@ -22,15 +35,8 @@ public class ClasspathHelper {
         }
 
         if (inputStream == null) {
-            throw new DotenvException("Could not find "+location+" on the classpath");
+            throw new DotenvException("Could not find "+ location +" on the classpath");
         }
-
-        final var scanner = new Scanner(inputStream, StandardCharsets.UTF_8);
-        final var lines = new ArrayList<String>();
-        while (scanner.hasNext()) {
-            lines.add(scanner.nextLine());
-        }
-
-        return lines.stream();
+        return inputStream;
     }
 }

--- a/src/main/java/io/github/cdimascio/dotenv/internal/DotenvFileReader.java
+++ b/src/main/java/io/github/cdimascio/dotenv/internal/DotenvFileReader.java
@@ -1,0 +1,54 @@
+package io.github.cdimascio.dotenv.internal;
+
+import io.github.cdimascio.dotenv.DotenvException;
+
+import java.io.File;
+import java.net.URI;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * (Internal) Reads a .env file
+ */
+public class DotenvFileReader extends BaseDotenvReader {
+    /**
+     * Creates a dotenv reader bases on File api
+     * @param directory the directory containing the .env file
+     * @param filename the file name of the .env file e.g. .env
+     */
+    public DotenvFileReader(String directory, String filename) {
+        super(directory, filename);
+    }
+
+    /**
+     * (Internal) Reads the .env file
+     * @return a list containing the contents of each line in the .env file
+     * @throws DotenvException if a dotenv error occurs
+     */
+    public List<String> read() throws DotenvException {
+        String dir = sanitizeDirectory();
+
+        String location = dir + "/" + filename;
+        String lowerLocation = location.toLowerCase();
+
+        File file = lowerLocation.startsWith("file:") || lowerLocation.startsWith("android.resource:")
+            ? new File(URI.create(location))
+            : new File(location);
+
+        try {
+            var classpathLocation = file.exists() ? file.getPath() : location.replaceFirst("^\\./", "/");
+            return ClasspathHelper
+                .loadFileFromClasspath(classpathLocation)
+                .collect(Collectors.toList());
+        } catch (DotenvException e) {
+            Path cwd = FileSystems.getDefault().getPath(".").toAbsolutePath().normalize();
+            String cwdMessage = !file.isAbsolute() ? "(working directory: " + cwd + ")" : "";
+            e.addSuppressed(new DotenvException("Could not find " + file.getPath() + " on the file system " + cwdMessage));
+            throw e;
+        }
+    }
+
+
+}

--- a/src/main/java/io/github/cdimascio/dotenv/internal/DotenvPathReader.java
+++ b/src/main/java/io/github/cdimascio/dotenv/internal/DotenvPathReader.java
@@ -1,0 +1,59 @@
+package io.github.cdimascio.dotenv.internal;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import io.github.cdimascio.dotenv.DotenvException;
+
+/**
+ * (Internal) Reads a .env file
+ */
+public class DotenvPathReader extends BaseDotenvReader {
+    /**
+     * Creates a dotenv reader based on the Path and Files
+     *
+     * @param directory the directory containing the .env file
+     * @param filename the file name of the .env file e.g. .env
+     */
+    public DotenvPathReader(String directory, String filename) {
+        super(directory, filename);
+    }
+
+    /**
+     * (Internal) Reads the .env file
+     * @return a list containing the contents of each line in the .env file
+     * @throws DotenvException if a dotenv error occurs
+     * @throws IOException if an I/O error occurs
+     */
+    public List<String> read() throws DotenvException, IOException {
+        String dir = sanitizeDirectory();
+
+        String location = dir + "/" + filename;
+        String lowerLocation = location.toLowerCase();
+
+        Path path = lowerLocation.startsWith("file:") || lowerLocation.startsWith("android.resource:")
+            ? Paths.get(URI.create(location))
+            : Paths.get(location);
+
+        if (Files.exists(path)) {
+            return Files.readAllLines(path);
+        }
+
+        try {
+            return ClasspathHelper
+                .loadFileFromClasspath(location.replaceFirst("^\\./", "/"))
+                .collect(Collectors.toList());
+        } catch (DotenvException e) {
+            Path cwd = FileSystems.getDefault().getPath(".").toAbsolutePath().normalize();
+            String cwdMessage = !path.isAbsolute() ? "(working directory: " + cwd + ")" : "";
+            e.addSuppressed(new DotenvException("Could not find " + path + " on the file system " + cwdMessage));
+            throw e;
+        }
+    }
+}

--- a/src/main/java/io/github/cdimascio/dotenv/internal/DotenvReader.java
+++ b/src/main/java/io/github/cdimascio/dotenv/internal/DotenvReader.java
@@ -3,62 +3,14 @@ package io.github.cdimascio.dotenv.internal;
 import io.github.cdimascio.dotenv.DotenvException;
 
 import java.io.IOException;
-import java.net.URI;
-import java.nio.file.FileSystems;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
-import java.util.stream.Collectors;
 
-/**
- * (Internal) Reads a .env file
- */
-public class DotenvReader {
-    private final String directory;
-    private final String filename;
-
+public interface DotenvReader {
     /**
-     * Creates a dotenv reader
-     * @param directory the directory containing the .env file
-     * @param filename the file name of the .env file e.g. .env
-     */
-    public DotenvReader(String directory, String filename) {
-        this.directory = directory;
-        this.filename = filename;
-    }
-
-    /**
-     * (Internal) Reads the .env file
+     * Reads the .env file
      * @return a list containing the contents of each line in the .env file
      * @throws DotenvException if a dotenv error occurs
      * @throws IOException if an I/O error occurs
      */
-    public List<String> read() throws DotenvException, IOException {
-        String dir = directory
-            .replaceAll("\\\\", "/")
-            .replaceFirst("\\.env$", "")
-            .replaceFirst("/$", "");
-
-        String location = dir + "/" + filename;
-        String lowerLocation = location.toLowerCase();
-        Path path = lowerLocation.startsWith("file:") || lowerLocation.startsWith("android.resource:")
-            ? Paths.get(URI.create(location))
-            : Paths.get(location);
-
-        if (Files.exists(path)) {
-            return Files.readAllLines(path);
-        }
-
-        try {
-            return ClasspathHelper
-                .loadFileFromClasspath(location.replaceFirst("^\\./", "/"))
-                .collect(Collectors.toList());
-        } catch (DotenvException e) {
-            Path cwd = FileSystems.getDefault().getPath(".").toAbsolutePath().normalize();
-            String cwdMessage = !path.isAbsolute() ? "(working directory: " + cwd + ")" : "";
-            e.addSuppressed(new DotenvException("Could not find " + path + " on the file system " + cwdMessage));
-            throw e;
-        }
-    }
+    List<String> read() throws DotenvException, IOException;
 }

--- a/src/main/java/io/github/cdimascio/dotenv/internal/FileClasspathHelper.java
+++ b/src/main/java/io/github/cdimascio/dotenv/internal/FileClasspathHelper.java
@@ -1,0 +1,36 @@
+package io.github.cdimascio.dotenv.internal;
+
+import io.github.cdimascio.dotenv.DotenvException;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Classpath helper
+ */
+public class FileClasspathHelper {
+    static List<String> loadFileFromClasspath(String location) {
+        InputStream inputStream = ClasspathHelper.getInputStream(location);
+        return readLines(inputStream);
+    }
+
+    public static List<String> readLines(InputStream inputStream) {
+        var list = new LinkedList<String>();
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream))) {
+            String line = reader.readLine();
+            while (line != null) {
+                line = reader.readLine();
+                if (line == null) {
+                    break;
+                }
+                list.add(line);
+            }
+            return list;
+        } catch (Exception e) {
+        }
+        throw new DotenvException("could not read file content");
+    }
+}

--- a/src/test/java/io/github/cdimascio/dotenv/DotenvReaderTests.java
+++ b/src/test/java/io/github/cdimascio/dotenv/DotenvReaderTests.java
@@ -1,0 +1,28 @@
+package io.github.cdimascio.dotenv;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DotenvReaderTests {
+
+    @Test
+    void verifyDotenvFileReader() {
+        DotenvBuilder builder = Mockito.mock(DotenvBuilder.class);
+        Mockito.when(builder.pathsApiAvailable()).thenReturn(false);
+        final var dotenv = Dotenv.configure().ignoreIfMalformed().load();
+        final String value = dotenv.get("MY_TEST_EV2");
+        assertEquals("my test ev 2", value);
+    }
+
+    @Test
+    void verifyDotenvPathReader() {
+        DotenvBuilder builder = Mockito.mock(DotenvBuilder.class);
+        Mockito.when(builder.pathsApiAvailable()).thenReturn(true);
+        final var dotenv = Dotenv.configure().ignoreIfMalformed().load();
+        final String value = dotenv.get("MY_TEST_EV1");
+        assertEquals("my test ev 1", value);
+    }
+
+}


### PR DESCRIPTION
- Add DotenvReader file reading implementation based on the File api to provide support for older android versions. 
See [Crashes_on_Android_version_7_and_older.](https://github.com/cdimascio/dotenv-kotlin/issues/60)
- Encapsulate File reading logic behind a DotenvReader interface to be able to provide different implementations at runtime. 
- Add reflection based way to determine which implementation to use.