### PR TITLE
Allow duplicate keys for variables

### DIFF
--- a/src/main/java/io/github/cdimascio/dotenv/DotenvBuilder.java
+++ b/src/main/java/io/github/cdimascio/dotenv/DotenvBuilder.java
@@ -88,7 +88,7 @@ public class DotenvBuilder {
         public DotenvImpl(final List<DotenvEntry> envVars) {
             final Map<String, String> envVarsInFile =
                 envVars.stream()
-                       .collect(toMap(DotenvEntry::getKey, DotenvEntry::getValue));
+                       .collect(toMap(DotenvEntry::getKey, DotenvEntry::getValue, (a, b) -> b));
 
             this.envVars = new HashMap<>(envVarsInFile);
             this.envVars.putAll(System.getenv());

--- a/src/test/java/tests/BasicTests.java
+++ b/src/test/java/tests/BasicTests.java
@@ -39,6 +39,16 @@ class BasicTests {
     }
 
     @Test
+    void dotenvDuplicateVariable() {
+        final var dotenv = Dotenv.configure()
+            .directory("./duplicateVariable")
+            .load();
+
+        assertEquals("Overridden Again Variable", dotenv.get("MY_TEST_EV1"));
+        assertEquals("Variable 2", dotenv.get("MY_TEST_EV2"));
+    }
+
+    @Test
     void dotenvFilename() {
         final var dotenv = Dotenv.configure()
             .directory("./src/test/resources")

--- a/src/test/resources/duplicateVariable/.env
+++ b/src/test/resources/duplicateVariable/.env
@@ -1,0 +1,6 @@
+MY_TEST_EV1=Simple Variable
+MY_TEST_EV1=Overridden Variable
+MY_TEST_EV1=Overridden Again Variable
+
+MY_TEST_EV2=Variable
+MY_TEST_EV2=Variable 2


### PR DESCRIPTION
Hi! In the GraphQL plugin for IntelliJ IDEA, we have an issue where .env files containing duplicate variables cause the plugin to fail silently. This PR addresses the problem by overwriting duplicate variables when encountered. I'm unsure whether this new behavior should be configurable via an additional setting or made the default. What do you think?

https://github.com/JetBrains/js-graphql-intellij-plugin/issues/722

I've checked [**dotenv**](https://github.com/motdotla/dotenv) Node.js package and it handles such cases the same way.

![image](https://github.com/user-attachments/assets/9b80a6c1-59fe-46e2-8c97-bf8d4e3a0b8a)
