### PR TITLE
Add dotenv import to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ value"
 
 
 ```java
+import io.github.cdimascio.dotenv.Dotenv;
+
 Dotenv dotenv = Dotenv.load();
 dotenv.get("MY_ENV_VAR1")
 ```


### PR DESCRIPTION
When reading the README, I appreciated the simple and to-the-point documentation of how to get a dotenv value:

```java
Dotenv dotenv = Dotenv.load();
dotenv.get("MY_ENV_VAR1")
```

However the full path of the import isn't anywhere in the readme (I found it in the example code). I figured other people might be looking for that in the readme, so I just added that line to the above example:

```java
import io.github.cdimascio.dotenv.Dotenv;
```

I know some IDEs can import symbols like `Dotenv` automatically, and I'm also aware that those lines won't run directly since the import goes outside the class and the `Dotenv.load()` would go inside some sort of main method, so I'm open to adding a `...` or otherwise restructuring that code snippet. What do you all think?